### PR TITLE
Reduced the artifacts in the images.

### DIFF
--- a/isaac_ws/simulation_ws/scripts/launch_sdg.py
+++ b/isaac_ws/simulation_ws/scripts/launch_sdg.py
@@ -10,6 +10,7 @@ HEADLESS=False
 SIMULATION_APP_CONFIG={
     "renderer": "RayTracedLighting",
     "headless": HEADLESS,
+    "anti_aliasing": "FXAA",
 }
 SEMANTIC_OBJECTS={
     "Apple": {
@@ -78,6 +79,9 @@ from omni.isaac.core.utils.semantics import remove_all_semantics
 from omni.isaac.core.utils.stage import get_current_stage, create_new_stage
 from omni.isaac.nucleus import get_assets_root_path
 import pxr
+
+# Configure replicator settings.
+rep.settings.carb_settings("/omni/replicator/RTSubframes", 3)
 
 # Get server path
 assets_root_path = get_assets_root_path()


### PR DESCRIPTION
The artifacts still occur but they are considerably less.

There are images with shadows from the previous frame but those only affect the background, creating interesting textures. The objects are not affected.

Closes #29

Some examples of old shadow projection in two continuous frame captures:

![rgb_0036](https://github.com/user-attachments/assets/58135433-10e4-48ba-8bec-771480d1f08a)

![rgb_0037](https://github.com/user-attachments/assets/0f5c653a-4d90-48c4-8e93-d1c453ecc05c)

Besides that, there is no more of the following:

![rgb_0007](https://github.com/user-attachments/assets/8fcf4ea2-511d-4159-9d6a-dc7c8a7bff97)


 