### PR TITLE
Fix datetime for datasets files generated.

### DIFF
--- a/isaac_ws/simulation_ws/scripts/launch_sdg.py
+++ b/isaac_ws/simulation_ws/scripts/launch_sdg.py
@@ -16,6 +16,7 @@
 
 import argparse
 import carb
+from datetime import datetime
 from isaacsim import SimulationApp
 import numpy as np
 import yaml
@@ -241,9 +242,13 @@ def main(args):
     # Initialize SimulationApp
     stamp_str = datetime.now().strftime("%Y%m%d%H%M%S")
     if "{{ timestamp }}" in config["WRITER_CONFIG"]["output_dir"]:
-        config["WRITER_CONFIG"]["output_dir"] = config["WRITER_CONFIG"]["output_dir"].replace("{{ timestamp }}", stamp_str)
-        
-    simulation_app = SimulationApp(launch_config=config["SIMULATION_APP_CONFIG"])
+        config["WRITER_CONFIG"]["output_dir"] = config["WRITER_CONFIG"][
+            "output_dir"
+        ].replace("{{ timestamp }}", stamp_str)
+
+    simulation_app = SimulationApp(
+        launch_config=config["SIMULATION_APP_CONFIG"],
+    )
 
     # Import Replicator after SimulationApp is initialized
     import omni.replicator.core as rep


### PR DESCRIPTION
The WRITER_CONFIG: output_dir wasn't creating properly the dataset path with the timestamp. The bug was fixed adding it as a Placeholder in the config.yml file and this placeholder is replaced with the current timestamp when the configuration is loaded.