### PR TITLE
Added a score threshold parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,17 @@ docker compose -f docker/docker-compose.yml --profile simulated_pipeline up
 docker compose -f docker/docker-compose.yml --profile simulated_pipeline down
 ```
 
-### Minimum bounding box tuning
+### Parameter tuning
 
-There are two parameters (`bbox_min_x` and `bbox_min_y`, both measured in pixels) available in the detection node, that can be used to filter the inferences based on the size of the bounding boxes generated. They can be modified via rqt_gui (Plugins -> Configuration -> Dynamic Reconfigure).
+The following detection node parameters are exposed and can be modified via rqt_gui when running any pipeline:
+
+#### Minimum bounding box
+
+The two parameters `bbox_min_x` and `bbox_min_y` are both measured in pixels. `bbox_min_x` can take values between 0 and 640, and `bbox_min_y` can take values between 0 and 480. They can be used to filter the inferences based on the size of the bounding boxes generated.
+
+#### Score threshold
+
+The parameter `score_threshold` takes values between 0.0 and 1.0. It can be used to filter inferences based on their confidence values.
 
 ## Bonus track: rosbags
 

--- a/detection_ws/src/fruit_detection/config/params.yml
+++ b/detection_ws/src/fruit_detection/config/params.yml
@@ -4,3 +4,6 @@
     model_path: "/root/detection_ws/model/model.pth"
     webcam_topic: "/image_raw"
     olive_camera_topic: "/olive/camera/id01/image/compressed"
+    bbox_min_x: 60
+    bbox_min_y: 60
+    score_threshold: 0.90


### PR DESCRIPTION
I tested two models: one trained with a 300-image dataset, and the other trained with a 5000-image dataset (both with synthetic data). I ran the rosbag and manually tested different values. For the bounding box, 60x60 pixels seem to be a good number when the objects are on the table, if they get closer to the camera, we sometimes get many small bounding boxes. For the score value, 0.9 seems to be a fine starting point: both models still have false positives, but the one trained with fewer images works better when having a score value closer to 0.95; the model trained with more images has more false positives at 0.9, but increasing that value makes it have fewer detections.

Closes #44 